### PR TITLE
fix: ensure ebook saver paths are pathlib-friendly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ pythonpath = [
   "src"
 ]
 addopts = "--timeout 300 -v -s --strict-markers -ra"
+markers = [
+  "asyncio: mark test as using asyncio",
+]
 
 [build-system]
 requires = ["pdm-backend"]

--- a/src/logic/saver/ebook.py
+++ b/src/logic/saver/ebook.py
@@ -59,7 +59,7 @@ class EbookSaver(Saver):
         paths = self.add_images_to_book(
             chapter_id=loaded_chapter.id, images=loaded_chapter.images
         )
-        paths = [".." / path for path in paths]
+        paths = [(Path("..") / path) for path in paths]
         html.set_content(
             f"<html><body><p>{loaded_chapter.title}</p><br/>{self.get_paragraph_html(loaded_chapter)}{self.get_images_html(paths)}</html>"
         )
@@ -73,10 +73,15 @@ class EbookSaver(Saver):
 
     def get_images_html(
         self,
-        paths: Iterable[Path],
+        paths: Iterable[Path | str],
         prefix: str = "<h1>Images</h1>",
     ):
-        html = "".join(f'<img src="{i}" alt="dead image----" />' for i in paths)
+        serialized_paths = [
+            path.as_posix() if isinstance(path, Path) else str(path) for path in paths
+        ]
+        html = "".join(
+            f'<img src="{i}" alt="dead image----" />' for i in serialized_paths
+        )
 
         return prefix + html if len(html) > 0 else ""
 

--- a/tests/logic/saver/test_ebook_saver.py
+++ b/tests/logic/saver/test_ebook_saver.py
@@ -1,0 +1,35 @@
+import asyncio
+from yarl import URL
+
+from domain.chapters import LoadedChapter
+from domain.images import LoadedImage
+from domain.saver_context import SaverContext
+from logic.saver.ebook import EbookSaver
+
+
+def test_save_chapter_with_image(monkeypatch):
+    context = SaverContext(title="Test Ebook", language="en", covers=[], author="Tester")
+
+    loaded_image = LoadedImage(url=URL("https://example.com/image.png"), data=b"image-bytes")
+    loaded_chapter = LoadedChapter(
+        id=1,
+        name="Chapter One",
+        url=URL("https://example.com/chapter-1"),
+        paragraphs=("Paragraph text.",),
+        images=(loaded_image,),
+        title="Chapter 1",
+    )
+
+    saver = EbookSaver(context=context)
+
+    def fake_write_epub(file_name: str, book) -> None:
+        assert file_name.endswith(".epub")
+        assert book is saver._book
+
+    monkeypatch.setattr("logic.saver.ebook.epub.write_epub", fake_write_epub)
+
+    async def run_save() -> None:
+        with saver:
+            await saver.save_chapter(loaded_chapter)
+
+    asyncio.run(run_save())


### PR DESCRIPTION
## Summary
- build relative image paths for ebook chapters using pathlib and POSIX serialization
- register the asyncio pytest marker and add a unit test covering chapter saving with images

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d670041c1c83259e0a0f98df2eae82