### PR TITLE
Fix Renovels pagination URL construction

### DIFF
--- a/src/logic/main_page/renovels.py
+++ b/src/logic/main_page/renovels.py
@@ -66,8 +66,8 @@ class RenovelsLoader(MainPageLoader):
         self, branch: int, count_chapters: int
     ) -> Sequence[Chapter]:
         count = 20
-        url = URL(
-            f"https://api.renovels.org/api/titles/chapters/?branch_id={branch}&ordering=index"
+        base_url = URL("https://api.renovels.org/api/titles/chapters/").with_query(
+            branch_id=branch, ordering="index"
         )
         tasks = []
         async with asyncio.TaskGroup() as tg:
@@ -75,7 +75,8 @@ class RenovelsLoader(MainPageLoader):
                 tasks.append(
                     tg.create_task(
                         get_text_response(
-                            self.session, url % {"count": count, "page": page + 1}
+                            self.session,
+                            base_url.update_query(count=count, page=page + 1),
                         )
                     )
                 )

--- a/tests/logic/main_page/test_renovels.py
+++ b/tests/logic/main_page/test_renovels.py
@@ -1,0 +1,37 @@
+import json
+
+import pytest
+from yarl import URL
+
+from logic.main_page.renovels import RenovelsLoader
+
+
+@pytest.mark.asyncio
+async def test_collect_chapters_builds_paginated_urls(monkeypatch):
+    captured_urls = []
+
+    async def fake_get_text_response(session, url):
+        captured_urls.append(url)
+        page = int(url.query["page"])
+        return json.dumps({"content": [{"id": page}]})
+
+    monkeypatch.setattr(
+        "logic.main_page.renovels.get_text_response", fake_get_text_response
+    )
+
+    loader = RenovelsLoader(URL("https://example.com"), object(), object())
+
+    chapters = await loader.collect_chapters(branch=7, count_chapters=45)
+
+    assert len(chapters) == 3
+    assert {chapter.id for chapter in chapters} == {1, 2, 3}
+
+    queries_by_page = {
+        url.query["page"]: {key: value for key, value in url.query.items()}
+        for url in captured_urls
+    }
+    assert queries_by_page == {
+        "1": {"branch_id": "7", "ordering": "index", "count": "20", "page": "1"},
+        "2": {"branch_id": "7", "ordering": "index", "count": "20", "page": "2"},
+        "3": {"branch_id": "7", "ordering": "index", "count": "20", "page": "3"},
+    }


### PR DESCRIPTION
## Summary
- build Renovels chapter pagination URLs using explicit query parameters when dispatching fetch tasks
- register the pytest asyncio marker and add a regression test that verifies the generated URLs

## Testing
- uv run pytest *(fails: unable to download build requirement `pdm-backend` in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d67004c8388325981adf41ef4626d9