### PR TITLE
fix: avoid duplicate cover extensions

### DIFF
--- a/src/logic/saver/ebook.py
+++ b/src/logic/saver/ebook.py
@@ -38,7 +38,12 @@ class EbookSaver(Saver):
 
             logger.debug("set epub cover")
             rnd_cover = choice(self.context.covers)
-            name = f"{rnd_cover.name}{rnd_cover.extension}"
+            cover_path = Path(rnd_cover.name)
+            extension = rnd_cover.extension
+            if extension:
+                name = cover_path.with_suffix(extension).name
+            else:
+                name = cover_path.name
             logger.debug(f"take {name}")
             content = rnd_cover.data
 

--- a/tests/logic/test_ebook_saver.py
+++ b/tests/logic/test_ebook_saver.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from yarl import URL
+
+from domain import LoadedImage, SaverContext
+from logic.saver.ebook import EbookSaver
+
+
+def test_cover_name_has_single_extension():
+    cover = LoadedImage(url=URL("https://example.com/cover.jpg"), data=b"data")
+    context = SaverContext(title="Title", language="en", covers=[cover])
+    saver = EbookSaver(context=context)
+    saver._book.set_cover = MagicMock()
+
+    saver.__enter__()
+
+    saver._book.set_cover.assert_called_once()
+    file_name = saver._book.set_cover.call_args.kwargs["file_name"]
+    expected_name = Path(cover.name).with_suffix(cover.extension).name
+
+    assert file_name == expected_name
+    assert file_name.endswith(cover.extension)
+    assert not file_name.endswith(cover.extension * 2)


### PR DESCRIPTION
## Summary
- ensure the ebook saver derives the cover file name using `Path` so the extension is not duplicated
- add a regression test to confirm the generated cover name ends with a single extension

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6700907488325b252b2efecc8fc98