### PR TITLE
Ensure middleware always shuts down resources

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -56,8 +56,13 @@ async def middleware():
     c = container.init_resources()
     if isinstance(c, Awaitable):
         await c
-    container.wire(modules=[__name__])
-    await main()
+    try:
+        container.wire(modules=[__name__])
+        await main()
+    finally:
+        shutdown = container.shutdown_resources()
+        if isinstance(shutdown, Awaitable):
+            await shutdown
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+from src import main as main_module
+
+
+class FakeContainer:
+    instances: list["FakeContainer"] = []
+
+    def __init__(self):
+        self.init_completed = False
+        self.shutdown_completed = False
+        type(self).instances.append(self)
+
+    def init_resources(self):
+        async def _init():
+            await asyncio.sleep(0)
+            self.init_completed = True
+
+        return _init()
+
+    def wire(self, modules):  # pragma: no cover - simple test double hook
+        self.modules = modules
+
+    def shutdown_resources(self):
+        async def _shutdown():
+            await asyncio.sleep(0)
+            self.shutdown_completed = True
+
+        return _shutdown()
+
+
+def test_middleware_shuts_down_resources(monkeypatch):
+    FakeContainer.instances = []
+
+    async def failing_main():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(main_module, "Container", FakeContainer)
+    monkeypatch.setattr(main_module, "main", failing_main)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(main_module.middleware())
+
+    assert FakeContainer.instances, "Container should have been instantiated"
+    instance = FakeContainer.instances[-1]
+    assert instance.init_completed
+    assert instance.shutdown_completed


### PR DESCRIPTION
## Summary
- wrap middleware execution in a try/finally block so container resources are always released
- add a regression test that injects a fake container to ensure shutdown_resources is awaited

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6701181b4832596a652d7e906f8ce